### PR TITLE
Make it easy to build under MacOS (with brew)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,12 @@
 SHELL := bash
 .SHELLFLAGS := -o pipefail -euc
 
-# Detect if running on macOS and if Homebrew is installed
+# Detect if running on macOS and if Homebrew is installed; check for GNU Make and GNU coreutils/findutils/sed/tar
 ifeq ($(shell uname), Darwin)
+  MAKE_VERSION := $(shell $(MAKE) -v | awk '/GNU Make/ {print $$3}')
+  ifeq ($(shell expr $(MAKE_VERSION) \< 4), 1)
+    $(error "GNU Make 4.x is required (Current version: $(MAKE_VERSION)) Install it via Homebrew with 'brew install make' and use 'gmake' instead of 'make'.")
+  endif
   ifeq ($(shell command -v brew 2>/dev/null), /usr/local/bin/brew)
     HOMEBREW_PREFIX := $(shell brew --prefix)
     PATH := $(HOMEBREW_PREFIX)/opt/coreutils/libexec/gnubin:$(HOMEBREW_PREFIX)/opt/gnu-sed/libexec/gnubin:$(HOMEBREW_PREFIX)/opt/gnu-tar/libexec/gnubin:$(HOMEBREW_PREFIX)/opt/findutils/libexec/gnubin:$(PATH)

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,14 @@
 SHELL := bash
 .SHELLFLAGS := -o pipefail -euc
 
+# Detect if running on macOS and if Homebrew is installed
+ifeq ($(shell uname), Darwin)
+  ifeq ($(shell command -v brew 2>/dev/null), /usr/local/bin/brew)
+    HOMEBREW_PREFIX := $(shell brew --prefix)
+    PATH := $(HOMEBREW_PREFIX)/opt/coreutils/libexec/gnubin:$(HOMEBREW_PREFIX)/opt/gnu-sed/libexec/gnubin:$(HOMEBREW_PREFIX)/opt/gnu-tar/libexec/gnubin:$(HOMEBREW_PREFIX)/opt/findutils/libexec/gnubin:$(PATH)
+  endif
+endif
+
 GIT_COMMIT := $(shell git rev-parse --short HEAD)
 GIT_TAG := $(shell git describe --tags --exact-match 2>/dev/null || true)
 ifeq ($(GIT_TAG),)


### PR DESCRIPTION
Apple's own tools are either not-GNU or old. Detect Darwin and Homebrew, stop if not using 4.x make, recommend `gmake`; prepend GNU versions of tools to PATH.